### PR TITLE
Add isTypeNonBlank method to Problem iface

### DIFF
--- a/src/main/java/io/github/malczuuu/problem4j/core/Problem.java
+++ b/src/main/java/io/github/malczuuu/problem4j/core/Problem.java
@@ -3,7 +3,6 @@ package io.github.malczuuu.problem4j.core;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -127,8 +126,8 @@ public interface Problem extends Serializable {
    *
    * @return {@code true} if {@code type} is assigned to a non-blank value, {@code false} otherwise
    */
-  default boolean hasType() {
-    return getType() != null && !Objects.equals(getType(), BLANK_TYPE);
+  default boolean isTypeNonBlank() {
+    return getType() != null && !getType().equals(BLANK_TYPE) && !getType().toString().isEmpty();
   }
 
   /** Represents a single key-value extension in a {@link Problem}. */

--- a/src/test/java/io/github/malczuuu/problem4j/core/ProblemBuilderImplTests.java
+++ b/src/test/java/io/github/malczuuu/problem4j/core/ProblemBuilderImplTests.java
@@ -25,7 +25,7 @@ class ProblemBuilderImplTests {
     Problem problem = Problem.builder().type((URI) null).build();
 
     assertThat(problem.getType()).isEqualTo(Problem.BLANK_TYPE);
-    assertThat(problem.hasType()).isFalse();
+    assertThat(problem.isTypeNonBlank()).isFalse();
   }
 
   @Test
@@ -33,7 +33,7 @@ class ProblemBuilderImplTests {
     Problem problem = Problem.builder().type((String) null).build();
 
     assertThat(problem.getType()).isEqualTo(Problem.BLANK_TYPE);
-    assertThat(problem.hasType()).isFalse();
+    assertThat(problem.isTypeNonBlank()).isFalse();
   }
 
   @Test
@@ -41,7 +41,7 @@ class ProblemBuilderImplTests {
     Problem problem = Problem.builder().type(Problem.BLANK_TYPE).build();
 
     assertThat(problem.getType()).isEqualTo(Problem.BLANK_TYPE);
-    assertThat(problem.hasType()).isFalse();
+    assertThat(problem.isTypeNonBlank()).isFalse();
   }
 
   @Test
@@ -49,7 +49,7 @@ class ProblemBuilderImplTests {
     Problem problem = Problem.builder().type(Problem.BLANK_TYPE.toString()).build();
 
     assertThat(problem.getType()).isEqualTo(Problem.BLANK_TYPE);
-    assertThat(problem.hasType()).isFalse();
+    assertThat(problem.isTypeNonBlank()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
MR adds a simple convenience method to check if `type` field was assigned by matching either null or blank value as not assigned.

Name of the method (`hasType`) is still up to discussion.