### PR TITLE
Allow creating ProblemMapper with ServiceLoader

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     testRuntimeOnly(libs.junit.platform.launcher)
 
     testImplementation(libs.assertj.core)
+    testImplementation(libs.mockito.core)
 }
 
 // see buildSrc/src/main/kotlin/internal.publishing-convention.gradle.kts

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 assertj = "3.27.7"
 junit = "6.0.2"
+mockito = "5.21.0"
 nmcp = "1.4.4"
 spotless = "8.2.0"
 
@@ -14,6 +15,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 
 # direct versions
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 
 # versions managed by junit-bom
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/src/main/java/io/github/problem4j/core/ProblemMapper.java
+++ b/src/main/java/io/github/problem4j/core/ProblemMapper.java
@@ -50,10 +50,14 @@ public interface ProblemMapper {
    * Creates a default {@link ProblemMapper} instance. The returned mapper provides the standard
    * mapping behavior defined by this library.
    *
+   * <p>To configure a custom implementation, create a file named {@code
+   * META-INF/services/io.github.problem4j.core.ProblemMapper} in your classpath, and list the fully
+   * qualified class name of your implementation in that file.
+   *
    * @return a new {@link ProblemMapper} instance
    */
   static ProblemMapper create() {
-    return new ProblemMapperImpl();
+    return ProblemMapperInstance.createInstance();
   }
 
   /**

--- a/src/main/java/io/github/problem4j/core/ProblemMapperInstance.java
+++ b/src/main/java/io/github/problem4j/core/ProblemMapperInstance.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Damian Malczewski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.problem4j.core;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+/**
+ * Helper class to create {@link ProblemMapper} instances by delegating it to {@link ServiceLoader}.
+ */
+final class ProblemMapperInstance {
+
+  /**
+   * Creates a default {@link ProblemMapper} instance. The returned mapper provides the standard
+   * mapping behavior defined by this library.
+   *
+   * <p>This method attempts to load a {@link ProblemMapper} implementation using the {@link
+   * ServiceLoader} mechanism. If no implementation is found or if an error occurs during loading,
+   * it falls back to the default {@link ProblemMapperImpl}.
+   *
+   * <p>To configure a custom implementation, create a file named {@code
+   * META-INF/services/io.github.problem4j.core.ProblemMapper} in your classpath, and list the fully
+   * qualified class name of your implementation in that file.
+   *
+   * @return a new {@link ProblemMapper} instance
+   */
+  static ProblemMapper createInstance() {
+    try {
+      ServiceLoader<ProblemMapper> serviceLoader = ServiceLoader.load(ProblemMapper.class);
+
+      Iterator<ProblemMapper> iterator = serviceLoader.iterator();
+
+      while (iterator.hasNext()) {
+        try {
+          return iterator.next();
+        } catch (Throwable e) {
+          // ignore - try next
+        }
+      }
+    } catch (Throwable t) {
+      // ignore - fall back to default
+    }
+    return new ProblemMapperImpl();
+  }
+}

--- a/src/test/java/io/github/problem4j/core/ProblemMapperInstanceTest.java
+++ b/src/test/java/io/github/problem4j/core/ProblemMapperInstanceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Damian Malczewski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.problem4j.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class ProblemMapperInstanceTest {
+
+  @Test
+  void
+      givenNoServiceLoaderImplementation_whenLoad_ProblemMapper_thenReturnsDefaultImplementation() {
+    ProblemMapper mapper = ProblemMapperInstance.createInstance();
+
+    assertThat(mapper).isInstanceOf(ProblemMapperImpl.class);
+  }
+
+  @Test
+  void givenServiceLoaderThrowsException_whenLoad_ProblemMapper_thenReturnsDefaultImplementation() {
+    Iterator<ProblemMapper> iterator = mock();
+    when(iterator.hasNext()).thenReturn(true, false);
+    when(iterator.next()).thenThrow(new RuntimeException("test exception"));
+
+    ServiceLoader<ProblemMapper> serviceLoader = mock();
+    when(serviceLoader.iterator()).thenReturn(iterator);
+
+    ProblemMapper mapper;
+
+    try (MockedStatic<ServiceLoader<ProblemMapper>> mocked = mockStatic()) {
+      mocked.when(() -> ServiceLoader.load(ProblemMapper.class)).thenReturn(serviceLoader);
+      mapper = ProblemMapperInstance.createInstance();
+    }
+
+    assertThat(mapper).isInstanceOf(ProblemMapperImpl.class);
+  }
+
+  @Test
+  void givenServiceLoaderWithImplementation_whenLoad_ProblemMapper_thenReturnsThatImplementation() {
+    class DummyProblemMapper extends AbstractProblemMapper {}
+
+    Iterator<ProblemMapper> iterator = mock();
+    when(iterator.hasNext()).thenReturn(true, false);
+    when(iterator.next()).thenReturn(new DummyProblemMapper());
+
+    ServiceLoader<ProblemMapper> serviceLoader = mock();
+    when(serviceLoader.iterator()).thenReturn(iterator);
+
+    ProblemMapper mapper;
+
+    try (MockedStatic<ServiceLoader<ProblemMapper>> mocked = mockStatic()) {
+      mocked.when(() -> ServiceLoader.load(ProblemMapper.class)).thenReturn(serviceLoader);
+      mapper = ProblemMapperInstance.createInstance();
+    }
+
+    assertThat(mapper).isInstanceOf(DummyProblemMapper.class);
+  }
+}


### PR DESCRIPTION
`ProblemMapper` can be extended by the library's consumer. In order to allow `ProblemMapper.create()` to use 3rd party implementations, this commit introduces initialization via `ServiceLoader` with fallback to default `ProblemMapperImpl`.